### PR TITLE
ignore null lookahead

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -117,7 +117,8 @@ proto._readObject = function () {
     return this._readReset();
 
   } else {
-    throw new Error('Illegal lookahead: 0x' + la.toString(16));
+    return undefined;
+    //throw new Error('Illegal lookahead: 0x' + la.toString(16));
   }
 }
 


### PR DESCRIPTION
For some reason https://github.com/mhsjlw/minecraft-classic-anvil/blob/master/examples/level.dat can be read properly, but then it cannot be written back.

This is a hack to make it work anyway. But I think there's something that doesn't handle some kind of java serialization in java.io (this level.data file has likely been created by java5 or older)

This is more of an issue than a PR.

The value of la is 0 at that point.